### PR TITLE
Deprecated `go get` in v1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ variables, functions and methods. Within each of these categories, exported decl
 $ go get github.com/jdeflander/goarrange
 ```
 
+### v1.17 and later
+
+```sh
+$ go install github.com/jdeflander/goarrange
+```
+
 ## Usage
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ go get github.com/jdeflander/goarrange
 ### v1.17 and later
 
 ```sh
-$ go install github.com/jdeflander/goarrange
+$ go install github.com/jdeflander/goarrange@v1.0.0
 ```
 
 ## Usage


### PR DESCRIPTION
> Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.
>
> In Go 1.18, go get will no longer build packages; it will only be used to add, update, or remove dependencies in go.mod. > Specifically, go get will always act as if the -d flag were enabled.

```
go: downloading github.com/jdeflander/goarrange v1.0.0
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

Read more [here](https://golang.org/doc/go-get-install-deprecation).