### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ variables, functions and methods. Within each of these categories, exported decl
 ### go 1.16+
 
 ```sh
-go install github.com/jdeflander/goarrange@v1.0.0
+$ go install github.com/jdeflander/goarrange@v1.0
 ```
 
 ### pre go 1.16
 
 ```sh
-go get github.com/jdeflander/goarrange
+$ go get github.com/jdeflander/goarrange
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,8 +7,16 @@ variables, functions and methods. Within each of these categories, exported decl
 
 ## Installation
 
+### go 1.16+
+
 ```sh
 go install github.com/jdeflander/goarrange@v1.0.0
+```
+
+### pre go 1.16
+
+```sh
+go get github.com/jdeflander/goarrange
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ variables, functions and methods. Within each of these categories, exported decl
 ## Installation
 
 ```sh
-$ go get github.com/jdeflander/goarrange
+go install github.com/jdeflander/goarrange@v1.0.0
 ```
 
 ## Usage


### PR DESCRIPTION
Installing executables using `go get` is nog longer supported as of `go 1.18`, from the official release notes:

> go get no longer builds or installs packages in module-aware mode. go get is now dedicated to adjusting dependencies in go.mod. Effectively, the -d flag is always enabled. To install the latest version of an executable outside the context of the current module, use [go install example.com/cmd@latest](https://golang.org/ref/mod#go-install). Any [version query](https://golang.org/ref/mod#version-queries) may be used instead of latest. This form of go install was added in Go 1.16, so projects supporting older versions may need to provide install instructions for both go install and go get. go get now reports an error when used outside a module, since there is no go.mod file to update. In GOPATH mode (with GO111MODULE=off), go get still builds and installs packages, as before.